### PR TITLE
Fix Build Errors & Update Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
   - brew upgrade node 2>/dev/null || brew install node # Upgrade or install to latest Node.js.
   - /usr/local/bin/node -v && /usr/bin/env node -v && node -v # Verify they're all the same version.
   - brew upgrade yarn 2>/dev/null || brew install yarn # Upgrade or install to latest yarn.
-  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
-  - gem install xcpretty-travis-formatter --no-rdoc --no-ri --no-document --quiet
+  - gem install xcpretty --no-document --quiet
+  - gem install xcpretty-travis-formatter --no-document --quiet
   - yarn
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: osx
 language: objective-c
-osx_image: xcode9
+osx_image: xcode11.3
 xcode_workspace: cocoadialog.xcworkspace
 xcode_sdk: macosx10.13
 

--- a/Source/CDControl.m
+++ b/Source/CDControl.m
@@ -196,7 +196,7 @@
     }
 
     // Return the exit status
-    exit(self.exitStatus);
+    exit((int) self.exitStatus);
 }
 
 @end

--- a/Source/CDTerminal.m
+++ b/Source/CDTerminal.m
@@ -210,7 +210,7 @@
 
 - (void *(^)(CDTerminalExitCode)) exit {
     return ^void *(CDTerminalExitCode exitCode) {
-        exit(exitCode);
+        exit((int) exitCode);
     };
 }
 


### PR DESCRIPTION
I am not sure if casting is really the right option to fix the following error messages:

> Implicit conversion loses integer precision: 'CDTerminalExitCode' (aka 'enum CDTerminalExitCode') to 'int'

However, the updates in this pull request do make it possible to build the project using Xcode 11.3.1 on macOS 10.15.3 again.